### PR TITLE
fix empty result check

### DIFF
--- a/pywsdp/base/__init__.py
+++ b/pywsdp/base/__init__.py
@@ -20,7 +20,7 @@ from pywsdp.base.logger import WSDPLogger
 from pywsdp.base.exceptions import WSDPError
 
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 
 
 class WSDPBase:

--- a/pywsdp/modules/CtiOS/helpers.py
+++ b/pywsdp/modules/CtiOS/helpers.py
@@ -127,7 +127,7 @@ class DbManager:
             raise WSDPError(self.logger, exc) from exc
 
         # Control if not empty
-        if len(ids) <= 1:
+        if len(ids) < 1:
             msg = "Query has an empty result!"
             raise WSDPError(self.logger, msg)
 


### PR DESCRIPTION
Currently `"Query has an empty result!"` error is raised also on query result having single item.